### PR TITLE
Add all amsfonts

### DIFF
--- a/tools/tfm2json.js
+++ b/tools/tfm2json.js
@@ -13,7 +13,10 @@ function processTfmFile( fontname, filename ) {
 }
 
 var desiredFonts = [
-  "cmb10", "cmbsy10", "cmbsy6", "cmbsy7", "cmbsy8", "cmbsy9", "cmbx10", 
+  "cmbsy5", "dummy", "wncyb10", "wncyb5", "wncyb6", "wncyb7", "wncyb8", "wncyb9",
+  "wncyi10", "wncyi5", "wncyi6", "wncyi7", "wncyi8", "wncyi9", "wncyr10", "wncyr5",
+  "wncyr6", "wncyr7", "wncyr8", "wncyr9", "wncysc10", "wncyss10", "wncyss8", "wncyss9",
+  "cmmib5", "cmb10", "cmbsy10", "cmbsy6", "cmbsy7", "cmbsy8", "cmbsy9", "cmbx10", 
   "cmbx12", "cmbx5", "cmbx6", "cmbx7", "cmbx8", "cmbx9", "cmbxsl10", 
   "cmbxti10", "cmcsc10", "cmcsc8", "cmcsc9", "cmdunh10", "cmex10", 
   "cmex7", "cmex8", "cmex9", "cmff10", "cmfi10", "cmfib8", "cminch", 


### PR DESCRIPTION
As described in this [issue](https://github.com/artisticat1/obsidian-tikzjax/issues/60) adding the fonts helped me to draw an OpAmp witch was not possible before. 

> The error is caused by the _dvi2html_ node module. It cannot read the tfm fonts from the [amsfonts](https://ctan.org/pkg/amsfonts) out of the Base64 string because they are not present.
> 
> ## Steps to Resolve:
> 1. Install a Tex Distribution -> For Mac https://www.tug.org/mactex/.
> 2. Clone my fork of [dvi2html](https://github.com/nilswenning/dvi2html).
>    
>    * The fonts from tools/tfm2json.js have been added there.
> 3. Clone the [tikzjax](https://github.com/artisticat1/tikzjax) fork by artisticat1.
> 4. Change line 21 to `"dvi2html": "file:../dvi2html",`.
> 5. Clone [obsidian-tikzjax](https://github.com/artisticat1/obsidian-tikzjax).
> 6. In the dvi2html folder, run `npm i` & `npm run dev`.
> 7. In the tikzjax folder, run `npm i` & `npm run dev`.
> 8. Replace the newly generated tikzjax.js with the one from the obsidian-tikzjax folder.
> 9. In the obsidian-tikzjax folder, run `npm i` & `npm run dev`.

